### PR TITLE
feat(component-docs): update select usage and css-only docs

### DIFF
--- a/.changeset/weak-jars-trade.md
+++ b/.changeset/weak-jars-trade.md
@@ -1,0 +1,5 @@
+---
+'@tylertech/forge-mcp': minor
+---
+
+Expose CSS-only classes in component docs and update select usage example

--- a/src/tools/components/get-component-docs-tool.ts
+++ b/src/tools/components/get-component-docs-tool.ts
@@ -50,6 +50,7 @@ export class ComponentDocumentationTool extends BaseToolHandler<ComponentDocumen
                 'slots',
                 'css-custom-properties',
                 'css-parts',
+                'css-classes',
                 'states',
               ],
             },
@@ -195,6 +196,7 @@ export class ComponentDocumentationTool extends BaseToolHandler<ComponentDocumen
       slots: 'components/component-slots.md',
       'css-custom-properties': 'components/component-css-properties.md',
       'css-parts': 'components/component-css-parts.md',
+      'css-classes': 'components/component-css-classes.md',
       states: 'components/component-states.md',
     };
 

--- a/templates/components/component-css-classes.md
+++ b/templates/components/component-css-classes.md
@@ -1,0 +1,13 @@
+# {{name}} - CSS Classes
+
+**CSS-Only Variants**: These classes provide the visual styling of Forge components for native HTML elements. Use these when you need only the appearance without the component functionality. **Do not apply these classes to Forge components themselves.**
+
+{{#if hasCssClasses}}
+| CSS Class | Description |
+|-----------|-------------|
+{{#each cssClasses}}
+| `{{name}}` | {{#if description}}{{description}}{{else}}No description{{/if}} |
+{{/each}}
+{{else}}
+No CSS classes available for this component.
+{{/if}}

--- a/templates/usage/usage-examples.md
+++ b/templates/usage/usage-examples.md
@@ -791,6 +791,15 @@ menu.options = [
 
 ## Select (forge-select)
 
+The select component uses a native `change` event to notify of selection changes, so you can listen for it like this:
+
+```javascript
+const select = document.querySelector('forge-select');
+select.addEventListener('change', (event) => {
+  console.log('Selected value:', event.target.value);
+});
+```
+
 ```html
 <forge-select>
   <forge-option value="option1">Option 1</forge-option>

--- a/templates/usage/usage.md
+++ b/templates/usage/usage.md
@@ -107,6 +107,20 @@ document.querySelector("forge-autocomplete").addEventListener("forge-autocomplet
 
 ## Styling Components
 
+### CSS Classes (CSS-Only Variants)
+Some Forge components provide CSS-only variants through CSS classes. These are designed for styling native HTML elements when you need only the visual appearance without component functionality:
+
+```html
+<!-- Use CSS classes on native elements for appearance-only styling -->
+<button class="forge-button forge-button--raised">Native Button with Forge Styling</button>
+<div class="forge-card">
+  <h3>Native div with Forge card styling</h3>
+  <p>Content styled to match Forge components</p>
+</div>
+```
+
+**Important**: CSS classes are intended for native HTML elements only. Do not apply these classes to Forge components themselves.
+
 ### CSS Custom Properties
 Tyler Forge components can be customized using CSS custom properties:
 


### PR DESCRIPTION
- Expose CSS-only classes in component docs tool
- Add note about select change event in usage examples

Considerations:
- Might be worth updating usage examples to include CSS-only snippets. We'll see how LLMs do with that first.