### PR TITLE
feat: add API validation tool

### DIFF
--- a/.changeset/busy-kiwis-jog.md
+++ b/.changeset/busy-kiwis-jog.md
@@ -1,0 +1,5 @@
+---
+'@tylertech/forge-mcp': minor
+---
+
+Added a new component API validation tool

--- a/.changeset/empty-sites-bake.md
+++ b/.changeset/empty-sites-bake.md
@@ -1,0 +1,5 @@
+---
+'@tylertech/forge-mcp': minor
+---
+
+Added new `validate_component_api` tool

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Get instant access to Tyler Forge™ web component documentation directly in AI 
 
 - **Discover components** - Find the right component for your needs
 - **Generate code** - Get framework-specific examples (Angular, React, Vue, Svelte)
+- **Validate APIs** - Verify that component properties, attributes, events, and other APIs are correctly used
 - **Access design tokens** - Use colors, spacing, typography consistently
 - **Learn best practices** - Get implementation guidance and accessibility tips
 
@@ -105,6 +106,7 @@ The following tools are available for interacting with Tyler Forge documentation
 | `get_component_docs` | Get comprehensive documentation for Tyler Forge components in various formats: full API reference, summary overview, or structural usage examples. Returns component list when no component specified. |
 | `list_components` | Browse all available Tyler Forge components with descriptions. Returns a comprehensive table of all components with their purpose and capabilities. |
 | `find_components` | Search Tyler Forge components by name, description, or functionality with enhanced fuzzy matching. Supports multi-term queries like "app bar drawer". Returns all components when no query provided. |
+| `validate_component_api` | Validate Tyler Forge component API usage after code generation. Checks that properties, attributes, events, methods, slots, CSS properties, parts, and classes are valid. |
 | **Design System Tools** ||
 | `get_design_tokens` | Get Tyler Forge design tokens for consistent styling. Access color palettes, spacing scales, typography, animation, and other design system values. |
 | `setup_typography` | Access Tyler Forge typography setup instructions including font families, type scales, weights, and practical usage guidelines for consistent text styling. |

--- a/src/services/api-validation-service.ts
+++ b/src/services/api-validation-service.ts
@@ -1,0 +1,471 @@
+import { CEMComponentDeclaration } from '../types/cem.js';
+
+/**
+ * Represents the result of validating a single API item
+ */
+export interface ApiValidationResult {
+  name: string;
+  isValid: boolean;
+  isDeprecated?: boolean;
+  deprecationMessage?: string;
+  apiType: ApiType;
+}
+
+/**
+ * Types of APIs that can be validated
+ */
+export type ApiType =
+  | 'property'
+  | 'attribute'
+  | 'event'
+  | 'method'
+  | 'slot'
+  | 'cssProperty'
+  | 'cssPart'
+  | 'cssClass';
+
+/**
+ * Input for validating component APIs
+ */
+export interface ComponentApiValidationInput {
+  properties?: string[];
+  attributes?: string[];
+  events?: string[];
+  methods?: string[];
+  slots?: string[];
+  cssProperties?: string[];
+  cssParts?: string[];
+  cssClasses?: string[];
+}
+
+/**
+ * API item with name and description
+ */
+export interface ApiItem {
+  name: string;
+  description?: string;
+}
+
+/**
+ * Complete validation results for a component
+ */
+export interface ComponentValidationResults {
+  component: string;
+  tagName: string;
+  validApis: ApiValidationResult[];
+  invalidApis: ApiValidationResult[];
+  deprecatedApis: ApiValidationResult[];
+  totalValidated: number;
+  availableApis: {
+    properties: ApiItem[];
+    attributes: ApiItem[];
+    events: ApiItem[];
+    methods: ApiItem[];
+    slots: ApiItem[];
+    cssProperties: ApiItem[];
+    cssParts: ApiItem[];
+    cssClasses: ApiItem[];
+  };
+}
+
+/**
+ * Service for validating Tyler Forge component API usage
+ *
+ * This service provides comprehensive validation of component APIs including:
+ * - Properties and attributes
+ * - Events and methods
+ * - Slots, CSS properties, parts, and classes
+ * - Deprecation warnings
+ * - Suggestions for invalid API usage
+ */
+export class ApiValidationService {
+  /**
+   * Validate multiple API types for a component
+   */
+  public validateComponentApis(
+    component: CEMComponentDeclaration,
+    apis: ComponentApiValidationInput,
+  ): ComponentValidationResults {
+    const allResults: ApiValidationResult[] = [];
+
+    // Validate each API type if provided
+    if (apis.properties?.length) {
+      allResults.push(...this._validateProperties(component, apis.properties));
+    }
+    if (apis.attributes?.length) {
+      allResults.push(...this._validateAttributes(component, apis.attributes));
+    }
+    if (apis.events?.length) {
+      allResults.push(...this._validateEvents(component, apis.events));
+    }
+    if (apis.methods?.length) {
+      allResults.push(...this._validateMethods(component, apis.methods));
+    }
+    if (apis.slots?.length) {
+      allResults.push(...this._validateSlots(component, apis.slots));
+    }
+    if (apis.cssProperties?.length) {
+      allResults.push(
+        ...this._validateCssProperties(component, apis.cssProperties),
+      );
+    }
+    if (apis.cssParts?.length) {
+      allResults.push(...this._validateCssParts(component, apis.cssParts));
+    }
+    if (apis.cssClasses?.length) {
+      allResults.push(...this._validateCssClasses(component, apis.cssClasses));
+    }
+
+    // Separate results by validation status
+    const validApis = allResults.filter(r => r.isValid && !r.isDeprecated);
+    const invalidApis = allResults.filter(r => !r.isValid);
+    const deprecatedApis = allResults.filter(r => r.isValid && r.isDeprecated);
+
+    // Collect available APIs only for the categories that were requested
+    const availableApis = this._collectRequestedAvailableApis(component, apis);
+
+    return {
+      component: component.name,
+      tagName: component.tagName,
+      validApis,
+      invalidApis,
+      deprecatedApis,
+      totalValidated: allResults.length,
+      availableApis,
+    };
+  }
+
+  /**
+   * Validate component properties
+   */
+  private _validateProperties(
+    component: CEMComponentDeclaration,
+    propertyNames: string[],
+  ): ApiValidationResult[] {
+    const publicMembers =
+      component.members?.filter(
+        m => m.privacy === 'public' && m.kind === 'field',
+      ) || [];
+
+    return propertyNames.map(name => {
+      const property = publicMembers.find(m => m.name === name);
+
+      if (property) {
+        return {
+          name,
+          isValid: true,
+          isDeprecated: !!property.deprecated,
+          deprecationMessage: property.deprecated,
+          apiType: 'property' as const,
+        };
+      }
+
+      return {
+        name,
+        isValid: false,
+        apiType: 'property' as const,
+      };
+    });
+  }
+
+  /**
+   * Validate component attributes
+   */
+  private _validateAttributes(
+    component: CEMComponentDeclaration,
+    attributeNames: string[],
+  ): ApiValidationResult[] {
+    const attributes = component.attributes || [];
+
+    return attributeNames.map(name => {
+      const attribute = attributes.find(a => a.name === name);
+
+      if (attribute) {
+        return {
+          name,
+          isValid: true,
+          apiType: 'attribute' as const,
+        };
+      }
+
+      return {
+        name,
+        isValid: false,
+        apiType: 'attribute' as const,
+      };
+    });
+  }
+
+  /**
+   * Validate component events
+   */
+  private _validateEvents(
+    component: CEMComponentDeclaration,
+    eventNames: string[],
+  ): ApiValidationResult[] {
+    const events = component.events || [];
+
+    return eventNames.map(name => {
+      const event = events.find(e => e.name === name);
+
+      if (event) {
+        return {
+          name,
+          isValid: true,
+          apiType: 'event' as const,
+        };
+      }
+
+      return {
+        name,
+        isValid: false,
+        apiType: 'event' as const,
+      };
+    });
+  }
+
+  /**
+   * Validate component methods
+   */
+  private _validateMethods(
+    component: CEMComponentDeclaration,
+    methodNames: string[],
+  ): ApiValidationResult[] {
+    const publicMethods =
+      component.members?.filter(
+        m => m.privacy === 'public' && m.kind === 'method',
+      ) || [];
+
+    return methodNames.map(name => {
+      const method = publicMethods.find(m => m.name === name);
+
+      if (method) {
+        return {
+          name,
+          isValid: true,
+          isDeprecated: !!method.deprecated,
+          deprecationMessage: method.deprecated,
+          apiType: 'method' as const,
+        };
+      }
+
+      return {
+        name,
+        isValid: false,
+        apiType: 'method' as const,
+      };
+    });
+  }
+
+  /**
+   * Validate component slots
+   */
+  private _validateSlots(
+    component: CEMComponentDeclaration,
+    slotNames: string[],
+  ): ApiValidationResult[] {
+    const slots = component.slots || [];
+
+    return slotNames.map(name => {
+      const slot = slots.find(s => s.name === name);
+
+      if (slot) {
+        return {
+          name,
+          isValid: true,
+          apiType: 'slot' as const,
+        };
+      }
+
+      return {
+        name,
+        isValid: false,
+        apiType: 'slot' as const,
+      };
+    });
+  }
+
+  /**
+   * Validate CSS custom properties
+   */
+  private _validateCssProperties(
+    component: CEMComponentDeclaration,
+    cssPropertyNames: string[],
+  ): ApiValidationResult[] {
+    const cssProperties = component.cssProperties || [];
+
+    return cssPropertyNames.map(name => {
+      const cssProperty = cssProperties.find(p => p.name === name);
+
+      if (cssProperty) {
+        return {
+          name,
+          isValid: true,
+          apiType: 'cssProperty' as const,
+        };
+      }
+
+      return {
+        name,
+        isValid: false,
+        apiType: 'cssProperty' as const,
+      };
+    });
+  }
+
+  /**
+   * Validate CSS parts
+   */
+  private _validateCssParts(
+    component: CEMComponentDeclaration,
+    cssPartNames: string[],
+  ): ApiValidationResult[] {
+    const cssParts = component.cssParts || [];
+
+    return cssPartNames.map(name => {
+      const cssPart = cssParts.find(p => p.name === name);
+
+      if (cssPart) {
+        return {
+          name,
+          isValid: true,
+          apiType: 'cssPart' as const,
+        };
+      }
+
+      return {
+        name,
+        isValid: false,
+        apiType: 'cssPart' as const,
+      };
+    });
+  }
+
+  /**
+   * Validate CSS classes
+   */
+  private _validateCssClasses(
+    component: CEMComponentDeclaration,
+    cssClassNames: string[],
+  ): ApiValidationResult[] {
+    const cssClasses = component.cssClasses || [];
+
+    return cssClassNames.map(name => {
+      const cssClass = cssClasses.find(c => c.name === name);
+
+      if (cssClass) {
+        return {
+          name,
+          isValid: true,
+          apiType: 'cssClass' as const,
+        };
+      }
+
+      return {
+        name,
+        isValid: false,
+        apiType: 'cssClass' as const,
+      };
+    });
+  }
+
+  /**
+   * Collect available APIs only for the categories that were requested for validation
+   */
+  private _collectRequestedAvailableApis(
+    component: CEMComponentDeclaration,
+    requestedApis: ComponentApiValidationInput,
+  ): {
+    properties: ApiItem[];
+    attributes: ApiItem[];
+    events: ApiItem[];
+    methods: ApiItem[];
+    slots: ApiItem[];
+    cssProperties: ApiItem[];
+    cssParts: ApiItem[];
+    cssClasses: ApiItem[];
+  } {
+    const publicMembers =
+      component.members?.filter(m => m.privacy === 'public') || [];
+
+    const result = {
+      properties: [] as ApiItem[],
+      attributes: [] as ApiItem[],
+      events: [] as ApiItem[],
+      methods: [] as ApiItem[],
+      slots: [] as ApiItem[],
+      cssProperties: [] as ApiItem[],
+      cssParts: [] as ApiItem[],
+      cssClasses: [] as ApiItem[],
+    };
+
+    // Only collect APIs for categories that were actually requested
+    if (requestedApis.properties?.length) {
+      result.properties = publicMembers
+        .filter(m => m.kind === 'field')
+        .map(m => ({
+          name: m.name,
+          description: m.description,
+        }));
+    }
+    if (requestedApis.attributes?.length) {
+      result.attributes = (component.attributes || []).map(a => ({
+        name: a.name,
+        description: a.description,
+      }));
+    }
+    if (requestedApis.events?.length) {
+      result.events = (component.events || []).map(e => ({
+        name: e.name,
+        description: e.description,
+      }));
+    }
+    if (requestedApis.methods?.length) {
+      result.methods = publicMembers
+        .filter(m => m.kind === 'method')
+        .map(m => ({
+          name: m.name,
+          description: m.description,
+        }));
+    }
+    if (requestedApis.slots?.length) {
+      result.slots = (component.slots || []).map(s => ({
+        name: s.name,
+        description: s.description,
+      }));
+    }
+    if (requestedApis.cssProperties?.length) {
+      result.cssProperties = (component.cssProperties || []).map(p => ({
+        name: p.name,
+        description: p.description,
+      }));
+    }
+    if (requestedApis.cssParts?.length) {
+      result.cssParts = (component.cssParts || []).map(p => ({
+        name: p.name,
+        description: p.description,
+      }));
+    }
+    if (requestedApis.cssClasses?.length) {
+      result.cssClasses = (component.cssClasses || []).map(c => ({
+        name: c.name,
+        description: c.description,
+      }));
+    }
+
+    return result;
+  }
+}
+
+// Singleton instance
+let apiValidationServiceInstance: ApiValidationService | null = null;
+
+/**
+ * Get the singleton API validation service instance
+ */
+export function getApiValidationService(): ApiValidationService {
+  if (!apiValidationServiceInstance) {
+    apiValidationServiceInstance = new ApiValidationService();
+  }
+  return apiValidationServiceInstance;
+}

--- a/src/services/handlebars-template-engine.ts
+++ b/src/services/handlebars-template-engine.ts
@@ -57,6 +57,7 @@ export class HandlebarsTemplateEngine {
     Handlebars.registerHelper('join', join);
     Handlebars.registerHelper('eq', eq);
     Handlebars.registerHelper('inc', inc);
+    Handlebars.registerHelper('and', and);
   }
 
   /**
@@ -215,6 +216,15 @@ export function eq(a: any, b: any): boolean {
  */
 export function inc(value: number): number {
   return value + 1;
+}
+
+/**
+ * Logical AND helper
+ */
+export function and(...args: any[]): boolean {
+  // Remove the last argument which is the Handlebars options object
+  const values = args.slice(0, -1);
+  return values.every(Boolean);
 }
 
 // Singleton instance

--- a/src/tools/components/validate-component-api-tool.ts
+++ b/src/tools/components/validate-component-api-tool.ts
@@ -133,8 +133,8 @@ export class ValidateComponentApiTool extends BaseToolHandler<ComponentApiValida
       apiArray => apiArray && apiArray.length > 0,
     );
     if (!hasApis) {
-      throw new Error(
-        'No APIs specified for validation. Provide at least one API type (properties, attributes, events, etc.).',
+      return this._createTextResponse(
+        'No APIs provided for validation. Component usage is correct.',
       );
     }
 

--- a/src/tools/components/validate-component-api-tool.ts
+++ b/src/tools/components/validate-component-api-tool.ts
@@ -1,0 +1,165 @@
+import { Tool } from '@modelcontextprotocol/sdk/types.js';
+import { BaseToolHandler, ToolInput } from '../tool-handler.js';
+import { getCEMLoader } from '../../services/cem-loader.js';
+import {
+  getApiValidationService,
+  ComponentApiValidationInput,
+  ComponentValidationResults,
+} from '../../services/api-validation-service.js';
+import { getTemplateEngine } from '../../services/handlebars-template-engine.js';
+
+export interface ComponentApiValidationToolInput extends ToolInput {
+  component: string;
+  apis?: ComponentApiValidationInput;
+}
+
+/**
+ * Tool for validating Tyler Forge component API usage after code generation
+ *
+ * This tool validates that component properties, attributes, events, methods,
+ * slots, CSS properties, parts, and classes are correctly used on Tyler Forge
+ * components. It identifies invalid APIs and warns about deprecated ones.
+ *
+ * Call this tool after generating code to ensure all component APIs are valid.
+ */
+export class ValidateComponentApiTool extends BaseToolHandler<ComponentApiValidationToolInput> {
+  private _cemLoader = getCEMLoader();
+  private _validationService = getApiValidationService();
+  private _templateEngine = getTemplateEngine();
+
+  constructor() {
+    super(
+      'validate_component_api',
+      'Validate Tyler Forge component API usage after code generation. Checks that properties, attributes, events, methods, slots, CSS properties, parts, and classes are valid. Use this tool to verify component usage is correct.',
+    );
+  }
+
+  public getTool(): Tool {
+    return {
+      name: this.name,
+      description: this.description,
+      inputSchema: {
+        type: 'object',
+        properties: {
+          component: {
+            type: 'string',
+            description:
+              'Component tag name (e.g., "forge-button", "forge-card")',
+          },
+          apis: {
+            type: 'object',
+            description: 'APIs to validate for the component',
+            properties: {
+              properties: {
+                type: 'array',
+                items: { type: 'string' },
+                description:
+                  'Property names to validate (e.g., ["disabled", "value"])',
+              },
+              attributes: {
+                type: 'array',
+                items: { type: 'string' },
+                description:
+                  'Attribute names to validate (e.g., ["disabled", "aria-label"])',
+              },
+              events: {
+                type: 'array',
+                items: { type: 'string' },
+                description:
+                  'Event names to validate (e.g., ["change", "click"])',
+              },
+              methods: {
+                type: 'array',
+                items: { type: 'string' },
+                description:
+                  'Method names to validate (e.g., ["focus", "click"])',
+              },
+              slots: {
+                type: 'array',
+                items: { type: 'string' },
+                description:
+                  'Slot names to validate (e.g., ["default", "header"])',
+              },
+              cssProperties: {
+                type: 'array',
+                items: { type: 'string' },
+                description:
+                  'CSS custom property names to validate (e.g., ["--forge-button-background"])',
+              },
+              cssParts: {
+                type: 'array',
+                items: { type: 'string' },
+                description:
+                  'CSS part names to validate (e.g., ["button", "label"])',
+              },
+              cssClasses: {
+                type: 'array',
+                items: { type: 'string' },
+                description:
+                  'CSS class names to validate (e.g., ["forge-button--raised"])',
+              },
+            },
+          },
+        },
+        required: ['component'],
+      },
+    };
+  }
+
+  public async execute(
+    args: ComponentApiValidationToolInput,
+  ): Promise<import('@modelcontextprotocol/sdk/types.js').CallToolResult> {
+    const { component, apis = {} } = args;
+
+    this._validateRequired(args, ['component']);
+
+    // Ensure CEM data is loaded
+    if (!this._cemLoader.isLoaded()) {
+      await this._cemLoader.loadCEM();
+    }
+
+    // Get component data
+    const componentData = this._cemLoader.getComponent(component);
+    if (!componentData) {
+      throw new Error(
+        `Component not found: ${component}. Available components: ${this._cemLoader
+          .getComponentTagNames()
+          .join(', ')}`,
+      );
+    }
+
+    // Check if there are any APIs to validate
+    const hasApis = Object.values(apis).some(
+      apiArray => apiArray && apiArray.length > 0,
+    );
+    if (!hasApis) {
+      throw new Error(
+        'No APIs specified for validation. Provide at least one API type (properties, attributes, events, etc.).',
+      );
+    }
+
+    // Perform validation
+    const validationResults = this._validationService.validateComponentApis(
+      componentData,
+      apis,
+    );
+
+    // Generate response using template
+    const responseText =
+      await this._generateValidationResponse(validationResults);
+
+    return this._createTextResponse(responseText);
+  }
+
+  /**
+   * Generate formatted validation response using template
+   */
+  private async _generateValidationResponse(
+    results: ComponentValidationResults,
+  ): Promise<string> {
+    return await this._templateEngine.render(
+      'components/validation-response.md',
+      results,
+    );
+  }
+}

--- a/src/tools/components/validate-component-api-tool.ts
+++ b/src/tools/components/validate-component-api-tool.ts
@@ -30,7 +30,7 @@ export class ValidateComponentApiTool extends BaseToolHandler<ComponentApiValida
   constructor() {
     super(
       'validate_component_api',
-      'Validate Tyler Forge component API usage after code generation. Checks that properties, attributes, events, methods, slots, CSS properties, parts, and classes are valid. Use this tool to verify component usage is correct.',
+      'Validate Tyler Forge component-specific API usage after code generation. DO NOT use this tool to validate standard HTML attributes (id, class, style, etc.), ARIA attributes (aria-*), or data attributes (data-*) - these are valid on all elements. Only validate component-specific properties, attributes, events, methods, slots, CSS properties, parts, and classes.',
     );
   }
 

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -6,6 +6,7 @@ export * from './tool-registry.js';
 export * from './components/get-component-docs-tool.js';
 export * from './components/list-components-tool.js';
 export * from './components/find-components-tool.js';
+export * from './components/validate-component-api-tool.js';
 
 // Usage and framework tools
 export * from './usage/get-usage-guide-tool.js';
@@ -27,6 +28,7 @@ import { ToolRegistry } from './tool-registry.js';
 import { ComponentDocumentationTool } from './components/get-component-docs-tool.js';
 import { ListComponentsTool } from './components/list-components-tool.js';
 import { SearchComponentsTool } from './components/find-components-tool.js';
+import { ValidateComponentApiTool } from './components/validate-component-api-tool.js';
 
 // Design system tools
 import { DesignTokensTool } from './design-system/get-design-tokens-tool.js';
@@ -51,6 +53,7 @@ export function createToolRegistry(): ToolRegistry {
   registry.register(new ComponentDocumentationTool());
   registry.register(new ListComponentsTool());
   registry.register(new SearchComponentsTool());
+  registry.register(new ValidateComponentApiTool());
 
   // Register design system tools
   registry.register(new DesignTokensTool());

--- a/templates/components/validation-response.md
+++ b/templates/components/validation-response.md
@@ -6,13 +6,21 @@
 ## Summary
 
 - ✅ **Valid APIs:** {{validApis.length}}
-- ❌ **Invalid APIs:** {{invalidApis.length}}
+- ❌ **Unmatched APIs:** {{invalidApis.length}}
 - ⚠️ **Deprecated APIs:** {{deprecatedApis.length}}
 
-{{#if invalidApis.length}}
-## ❌ Invalid APIs
+## 📋 Important Context
 
-These APIs do not exist on this component:
+**Standard HTML attributes are always valid:** Standard HTML attributes (aria-*, data-*, id, class, role, tabindex, etc.) are valid on all web components even if not listed in metadata. Do NOT remove these attributes.
+
+**This tool validates API names only:** Only use this tool to fix incorrect component-specific API names (properties, attributes, events, methods, slots, CSS properties/parts/classes). Replace unmatched component APIs with the correct names from the "Available APIs" section below.
+
+**For structural validation:** Do NOT restructure code based on this tool alone. Use the component usage examples tool to verify correct component structure and patterns.
+
+{{#if invalidApis.length}}
+## ❌ Unmatched APIs
+
+These APIs were not found in component metadata. Standard HTML/ARIA/data-* attributes can be safely ignored. For component-specific APIs, check Available APIs below for correct names:
 
 {{#each invalidApis}}
 - **`{{name}}`** ({{apiType}})
@@ -43,7 +51,7 @@ These APIs are correctly available:
 {{#if invalidApis.length}}
 ## 📚 Available APIs
 
-For reference, here are the relevant available APIs for this component:
+Component-specific APIs available (use these to replace unmatched component APIs):
 
 {{#if availableApis.properties.length}}
 **Properties:**

--- a/templates/components/validation-response.md
+++ b/templates/components/validation-response.md
@@ -1,0 +1,100 @@
+# API Validation Results: {{tagName}}
+
+**Component:** `<{{tagName}}>`
+**Total APIs Validated:** {{totalValidated}}
+
+## Summary
+
+- ✅ **Valid APIs:** {{validApis.length}}
+- ❌ **Invalid APIs:** {{invalidApis.length}}
+- ⚠️ **Deprecated APIs:** {{deprecatedApis.length}}
+
+{{#if invalidApis.length}}
+## ❌ Invalid APIs
+
+These APIs do not exist on this component:
+
+{{#each invalidApis}}
+- **`{{name}}`** ({{apiType}})
+{{/each}}
+
+{{/if}}
+{{#if deprecatedApis.length}}
+## ⚠️ Deprecated APIs
+
+These APIs exist but are deprecated:
+
+{{#each deprecatedApis}}
+- **`{{name}}`** ({{apiType}}){{#if deprecationMessage}}
+  - 📝 **Deprecation:** {{deprecationMessage}}{{/if}}
+{{/each}}
+
+{{/if}}
+{{#if validApis.length}}
+## ✅ Valid APIs
+
+These APIs are correctly available:
+
+{{#each validApis}}
+- **`{{name}}`** ({{apiType}})
+{{/each}}
+
+{{/if}}
+{{#if invalidApis.length}}
+## 📚 Available APIs
+
+For reference, here are the relevant available APIs for this component:
+
+{{#if availableApis.properties.length}}
+**Properties:**
+{{#each availableApis.properties}}
+- **`{{name}}`**{{#if description}} - {{description}}{{/if}}
+{{/each}}
+{{/if}}
+{{#if availableApis.attributes.length}}
+**Attributes:**
+{{#each availableApis.attributes}}
+- **`{{name}}`**{{#if description}} - {{description}}{{/if}}
+{{/each}}
+{{/if}}
+{{#if availableApis.events.length}}
+**Events:**
+{{#each availableApis.events}}
+- **`{{name}}`**{{#if description}} - {{description}}{{/if}}
+{{/each}}
+{{/if}}
+{{#if availableApis.methods.length}}
+**Methods:**
+{{#each availableApis.methods}}
+- **`{{name}}`**{{#if description}} - {{description}}{{/if}}
+{{/each}}
+{{/if}}
+{{#if availableApis.slots.length}}
+**Slots:**
+{{#each availableApis.slots}}
+- **`{{name}}`**{{#if description}} - {{description}}{{/if}}
+{{/each}}
+{{/if}}
+{{#if availableApis.cssProperties.length}}
+**CSS Properties:**
+{{#each availableApis.cssProperties}}
+- **`{{name}}`**{{#if description}} - {{description}}{{/if}}
+{{/each}}
+{{/if}}
+{{#if availableApis.cssParts.length}}
+**CSS Parts:**
+{{#each availableApis.cssParts}}
+- **`{{name}}`**{{#if description}} - {{description}}{{/if}}
+{{/each}}
+{{/if}}
+{{#if availableApis.cssClasses.length}}
+**CSS Classes:**
+{{#each availableApis.cssClasses}}
+- **`{{name}}`**{{#if description}} - {{description}}{{/if}}
+{{/each}}
+{{/if}}
+
+{{/if}}
+{{#if (and (eq invalidApis.length 0) (eq deprecatedApis.length 0))}}
+🎉 **All validated APIs are correct and up-to-date!**
+{{/if}}


### PR DESCRIPTION
Add component API validation tool that allows for LLMs to provide the tag name being validated, the APIs used, and the tool will return a summary response of whether those APIs are valid, deprecated, or invalid as well as the relevant APIs to consider for the types of APIs provided.

We need to determine if LLMs will actually utilize this tool effectively, but the goal is to improve accuracy and avoid the LLM making false assumptions about components APIs based on patterns of other components.