### PR TITLE
fix: support bundled manifests for missing packages

### DIFF
--- a/.changeset/quick-groups-move.md
+++ b/.changeset/quick-groups-move.md
@@ -1,0 +1,5 @@
+---
+'@tylertech/forge-mcp': patch
+---
+
+Allow using bundled manifest if package is not installed


### PR DESCRIPTION
Adds support for loading bundled manifest for missing packages if only forge or only forge-extended is installed.